### PR TITLE
svn-submodules

### DIFF
--- a/svn-submodules
+++ b/svn-submodules
@@ -6,4 +6,4 @@
 #        svn checkout -r $rev $repo $dir
 #    done
 #fi
-1093 http://ndt.googlcode.com/svn/trunk/ ndt-read-only
+1093 http://ndt.googlecode.com/svn/trunk/ ndt-read-only


### PR DESCRIPTION
This should allow ndt source to be pulled from Google Code via svn. Correspondingly, the tar-archive file should be emptied so that m-lab-tools/package/bootstrap.sh only pulls in download instructions from svn-submodules, not tar-archive. 
