### PR TITLE
Add official NDT git repo as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "package"]
 	path = package
 	url = https://github.com/m-lab/package
+[submodule "ndt"]
+	path = ndt
+	url = https://github.com/ndt-project/ndt.git

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -39,7 +39,7 @@ pushd $SOURCE_DIR/web100_userland-1.8
 popd
 
 # NOTE: unpacked from tar-archives by bootstrap.sh
-pushd $SOURCE_DIR/ndt-3.7.0.1
+pushd $SOURCE_DIR/ndt
     export CPPFLAGS="-I$BUILD_DIR/build/include -I$BUILD_DIR/build/include/web100"
     export LDFLAGS="-L$BUILD_DIR/build/lib"
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -42,6 +42,7 @@ popd
 pushd $SOURCE_DIR/ndt
     export CPPFLAGS="-I$BUILD_DIR/build/include -I$BUILD_DIR/build/include/web100"
     export LDFLAGS="-L$BUILD_DIR/build/lib"
+	./bootstrap
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
     make
     make install

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -42,7 +42,7 @@ popd
 pushd $SOURCE_DIR/ndt
     export CPPFLAGS="-I$BUILD_DIR/build/include -I$BUILD_DIR/build/include/web100"
     export LDFLAGS="-L$BUILD_DIR/build/lib"
-	./bootstrap
+    ./bootstrap
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
     make
     make install

--- a/tar-archives
+++ b/tar-archives
@@ -1,2 +1,1 @@
 web100_userland-1.8.tar.gz http://www.web100.org/download/userland/version1.8/web100_userland-1.8.tar.gz
-ndt-3.7.0.1.tar.gz http://software.internet2.edu/sources/ndt/ndt-3.7.0.1.tar.gz


### PR DESCRIPTION
Previously, the NDT releases were published as tar-gzipped archives, which this repository would download and unpack.  The offical NDT code repository is now in git and hosted on Github, which obviates the need to download an archive for an official release.  This pull request adds the official NDT repository as a submodule set to the commit of the release upon which our current NDT package is build from (3.7.0.1).  This pull request also removes NDT from the tar-archives file, which will prevent [bootstrap.sh](https://github.com/nkinkade/package/blob/master/bootstrap.sh#L46) from downloading a package and unpacking it in the source directory for the build.