### PR TITLE
Launch ndtd with SSL enabled, but only if key and cert exist.

### DIFF
--- a/init/start.sh
+++ b/init/start.sh
@@ -14,6 +14,7 @@ export LD_LIBRARY_PATH=/home/iupui_ndt/build/lib:$LD_LIBRARY_PATH
 # Paths to private key and certificate for SSL operation
 PRIVATE_KEY=/etc/pki/tls/private/measurement-lab.org.key
 SSL_CERT=/etc/pki/tls/certs/measurement-lab.org.crt
+TLS_PORT=5001
 
 # NOTE: explicityly disabled "--adminview" to avoid calculation error bug:
 # https://code.google.com/p/ndt/issues/detail?id=79
@@ -22,7 +23,7 @@ FAKEWWW_OPTIONS=""
 
 # Set SSL flags if private key and certificate exist
 if [ -f $PRIVATE_KEY ] && [ -f $SSL_CERT ]; then
-	SSL_OPTIONS="--tls --private_key $PRIVATE_KEY --certificate $SSL_CERT"
+	SSL_OPTIONS="--tls --tls_port $TLS_PORT --private_key $PRIVATE_KEY --certificate $SSL_CERT"
 	WEB100SRV_OPTIONS="${WEB100SRV_OPTIONS} $SSL_OPTIONS"
 fi
 

--- a/init/start.sh
+++ b/init/start.sh
@@ -11,10 +11,20 @@ export LD_LIBRARY_PATH=/home/iupui_ndt/build/lib:$LD_LIBRARY_PATH
 [ -f $path/ndtd ] || exit 0
 [ -f $path/fakewww ] || exit 0
 
+# Paths to private key and certificate for SSL operation
+PRIVATE_KEY=/etc/pki/tls/private/measurement-lab.org.key
+SSL_CERT=/etc/pki/tls/certs/measurement-lab.org.crt
+
 # NOTE: explicityly disabled "--adminview" to avoid calculation error bug:
 # https://code.google.com/p/ndt/issues/detail?id=79
 WEB100SRV_OPTIONS="--log_dir $SLICERSYNCDIR/ --snaplog --tcpdump --cputime --multiple --max_clients=40"
 FAKEWWW_OPTIONS=""
+
+# Set SSL flags if private key and certificate exist
+if [ -f $PRIVATE_KEY ] && [ -f $SSL_CERT ]; then
+	SSL_OPTIONS="--tls --private_key $PRIVATE_KEY --certificate $SSL_CERT"
+	WEB100SRV_OPTIONS="${WEB100SRV_OPTIONS} $SSL_OPTIONS"
+fi
 
 if ! pgrep -f ndtd &> /dev/null ; then
     echo "Starting ndtd:"


### PR DESCRIPTION
This pull request defines the location of the private key and SSL cert in the filesystem, and if both are present, will add options to ndtd to start with SSL enabled.