### PR TITLE
nohup NDT daemons in init/start.sh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "package"]
 	path = package
 	url = https://github.com/m-lab/package
-[submodule "ndt"]
-	path = ndt
-	url = https://github.com/ndt-project/ndt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "package"]
 	path = package
 	url = https://github.com/m-lab/package
+[submodule "ndt"]
+	path = ndt
+	url = git@github.com:m-lab/ndt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/m-lab/package
 [submodule "ndt"]
 	path = ndt
-	url = git@github.com:m-lab/ndt.git
+	url = https://github.com/m-lab/ndt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/m-lab/package
 [submodule "ndt"]
 	path = ndt
-	url = https://github.com/m-lab/ndt.git
+	url = https://github.com/ndt-project/ndt.git

--- a/init/start.sh
+++ b/init/start.sh
@@ -38,13 +38,13 @@ if ! pgrep -f ndtd &> /dev/null ; then
     [ -f $logpath/web100srv.log.1 ] && mv $logpath/web100srv.log.1 $logpath/web100srv.log.2
     [ -f $logpath/web100srv.log   ] && mv $logpath/web100srv.log $logpath/web100srv.log.1 
     # ndtd must run as root
-    $path/ndtd $WEB100SRV_OPTIONS > /dev/null 2>&1 &
+    nohup $path/ndtd $WEB100SRV_OPTIONS > /dev/null 2>&1 &
     touch /var/lock/subsys/ndtd
 fi
 
 if ! pgrep -f fakewww &> /dev/null ; then
     echo "Starting fakewww:"
-    $path/fakewww $FAKEWWW_OPTIONS > /dev/null 2>&1 &
+    nohup $path/fakewww $FAKEWWW_OPTIONS > /dev/null 2>&1 &
     touch /var/lock/subsys/fakewww
 fi
 
@@ -53,6 +53,6 @@ if ! pgrep -f flashpolicyd.py &> /dev/null ; then
     # rotate log file before starting
     [ -f $flashpolicyd_log.1 ] && mv $flashpolicyd_log.1 $flashpolicyd_log.2
     [ -f $flashpolicyd_log   ] && mv $flashpolicyd_log $flashpolicyd_log.1
-    $SLICEHOME/flashpolicyd.py > /dev/null 2> $flashpolicyd_log &
+    nohup $SLICEHOME/flashpolicyd.py > /dev/null 2> $flashpolicyd_log &
     touch /var/lock/subsys/flashpolicyd.py
 fi

--- a/init/start.sh
+++ b/init/start.sh
@@ -21,7 +21,7 @@ WEB100_VARS=$SLICEHOME/build/ndt/web100_variables
 
 # NOTE: explicityly disabled "--adminview" to avoid calculation error bug:
 # https://code.google.com/p/ndt/issues/detail?id=79
-WEB100SRV_OPTIONS="--log_dir $SLICERSYNCDIR/ --snaplog --tcpdump --cputime --multiple --max_clients=40 -f $WEB100_VARS"
+WEB100SRV_OPTIONS="--log_dir $SLICERSYNCDIR/ --snaplog --tcpdump --cputime --multiple --max_clients=40 --disable_extended_tests -f $WEB100_VARS"
 FAKEWWW_OPTIONS=""
 
 # Set SSL flags if private key and certificate exist


### PR DESCRIPTION
When using Ansible to test deploying certificates to machines, we were having an issue with fakewww and flashpolicyd not remaining started after running

`$ service slicectrl restart`

This change makes these daemons stay running in the background even when the terminal that started them exits.   This should assist with our use of Ansible on the platform yet have no consequence for anything else, in theory.