### PR TITLE
Enable NDT server debug log and add a simple daily rotating logger.

### DIFF
--- a/init/logger.py
+++ b/init/logger.py
@@ -9,14 +9,18 @@ import logging
 import logging.handlers
 
 
+SIZE_100_MB = 100000000
+
+
 if len(sys.argv) == 1:
   sys.stderr.write('Please provide filename for writing logs.')
   sys.exit(1)
 
-# Rotate the log file every 1 day ('d'), keeping at most 2 backups.
-# This means there can be three files: current, backup 1, backup 2.
-handler = logging.handlers.TimedRotatingFileHandler(
-    sys.argv[1], interval=1, when='d', backupCount=2, utc=True)
+# Rotate the log file when it contains SIZE_100_MB bytes, keeping at most 2
+# backups. This means there can be three files: current, backup 1, backup 2
+# whose total disk usage is 300 MB.
+handler = logging.handlers.RotatingFileHandler(
+    sys.argv[1], maxBytes=SIZE_100_MB, backupCount=2)
 
 # Default logger config does not prefix log messages with any extra information.
 log = logging.getLogger()

--- a/init/logger.py
+++ b/init/logger.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+"""logger.py reads from stdin and writes a log. Log files are rotated daily.
+
+At most two backup files are preserved.
+"""
+
+import sys
+import logging
+import logging.handlers
+
+
+if len(sys.argv) == 1:
+  sys.stderr.write('Please provide filename for writing logs.')
+  sys.exit(1)
+
+# Rotate the log file every 1 day ('d'), keeping at most 2 backups.
+# This means there can be three files: current, backup 1, backup 2.
+handler = logging.handlers.TimedRotatingFileHandler(
+    sys.argv[1], interval=1, when='d', backupCount=2, utc=True)
+
+# Default logger config does not prefix log messages with any extra information.
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+log.addHandler(handler)
+
+while True:
+  line = sys.stdin.readline()
+  if not line:
+    break
+  # Strip line to prevent double newlines in output.
+  log.info(line.rstrip())

--- a/init/start.sh
+++ b/init/start.sh
@@ -17,28 +17,28 @@ SSL_CERT=/etc/pki/tls/certs/measurement-lab.org.crt
 TLS_PORT=3010
 
 # Location of web100 variables file
-WEB100_VARS=$SLICEHOME/build/ndt/web100_variables 
+WEB100_VARS=$SLICEHOME/build/ndt/web100_variables
 
 # NOTE: explicityly disabled "--adminview" to avoid calculation error bug:
 # https://code.google.com/p/ndt/issues/detail?id=79
-WEB100SRV_OPTIONS="--log_dir $SLICERSYNCDIR/ --snaplog --tcpdump --cputime
+WEB100SRV_OPTIONS="-dddddd --log_dir $SLICERSYNCDIR/ --snaplog --tcpdump --cputime
                    --multiple --max_clients=40 --disable_extended_tests
                    -f $WEB100_VARS"
 FAKEWWW_OPTIONS=""
 
 # Set SSL flags if private key and certificate exist
 if [ -f $PRIVATE_KEY ] && [ -f $SSL_CERT ]; then
-	SSL_OPTIONS="--tls_port $TLS_PORT --private_key $PRIVATE_KEY --certificate $SSL_CERT"
-	WEB100SRV_OPTIONS="${WEB100SRV_OPTIONS} $SSL_OPTIONS"
+    SSL_OPTIONS="--tls_port $TLS_PORT --private_key $PRIVATE_KEY --certificate $SSL_CERT"
+    WEB100SRV_OPTIONS="${WEB100SRV_OPTIONS} $SSL_OPTIONS"
 fi
 
 if ! pgrep -f ndtd &> /dev/null ; then
     echo "Starting ndtd:"
     # rotate log file before starting
     [ -f $logpath/web100srv.log.1 ] && mv $logpath/web100srv.log.1 $logpath/web100srv.log.2
-    [ -f $logpath/web100srv.log   ] && mv $logpath/web100srv.log $logpath/web100srv.log.1 
+    [ -f $logpath/web100srv.log   ] && mv $logpath/web100srv.log $logpath/web100srv.log.1
     # ndtd must run as root
-    nohup $path/ndtd $WEB100SRV_OPTIONS > /dev/null 2>&1 &
+    nohup $path/ndtd $WEB100SRV_OPTIONS 2>&1 | $SLICEHOME/init/logger.py /var/log/web100srv.debug &
     touch /var/lock/subsys/ndtd
 fi
 


### PR DESCRIPTION
This change adds a simple logger for NDT's debug output. The logger reads from stdin and writes to a given filename. The log file is rotated daily to limit disk usage over time.

This change enables debugging from the NDT server.

This approach balances expediency with conservatism. 

Alternatives considered:

 1. just redirect to a file
 2. use utility like `split` or `rotatelog`
 3. use rsyslogd + unix `logger`

1) Does not limit the size of the file and requires restarting the server to reset the file size. This was previously an issue with the web100srv.log itself before rotation was added to the start script.
2) These are not quite right or are bundled with larger packages like Apache server that should not be installed within the NDT filesystem.
3) I think this is a preferable solution, but belongs as part of the m-lab/package repo so that it is auto enabled for all slices. Also, rsyslog uses a standard format and protocol that can be redirected from local to a remote server or to a single logging service per machine. Also, the number of new configuration files reduce confidence that the change would be complete if the need is more immediate. Also, this introduces a new service as a dependency.
