### PR TITLE
Do unit testing of the source code prior to building and installing.

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -44,6 +44,12 @@ pushd $SOURCE_DIR/ndt
     export LDFLAGS="-L$BUILD_DIR/build/lib"
     ./bootstrap
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
+    # Run unit tests on source before making and installing
+    make check
+    if [[ $? -ne 0 ]]; then
+        echo "Unit testing of the source code failed. Please contact the developers."
+        exit 1
+    fi
     make
     make install
 

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -45,11 +45,7 @@ pushd $SOURCE_DIR/ndt
     ./bootstrap
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
     # Run unit tests on source before making and installing
-    make check
-    if [[ $? -ne 0 ]]; then
-        echo "Unit testing of the source code failed. Please contact the developers."
-        exit 1
-    fi
+    make check || (echo "Unit testing of the source code failed." && exit 1)
     make
     make install
 

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -45,8 +45,8 @@ pushd $SOURCE_DIR/ndt
     ./bootstrap
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
     # Run unit tests on source before making and installing
-    make check || (echo "Unit testing of the source code failed." && exit 1)
     make
+    make check || (echo "Unit testing of the source code failed." && exit 1)
     make install
 
     # Applet gets remade if we do this before 'make install'


### PR DESCRIPTION
When building an NDT slice package, run the unit tests on the source code.  If the unit tests fail, then exit the build process with a message to contact the developers.