### PR TITLE
ndt submodule should point to the m-lab fork.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/m-lab/package
 [submodule "ndt"]
 	path = ndt
-	url = https://github.com/ndt-project/ndt.git
+	url = https://github.com/m-lab/ndt.git


### PR DESCRIPTION
This is a TBR PR. It simply points the ndt submodule to the m-lab/ndt repository as opposed to the ndt-project/ndt repository. I'm going to merge it and send a code review email after.  No code changes, but just updating a pointer.