### PR TITLE
Runs make-check after make-install

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -46,8 +46,8 @@ pushd $SOURCE_DIR/ndt
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
     # Run unit tests on source before making and installing
     make
-    make check || (echo "Unit testing of the source code failed." && exit 1)
     make install
+    make check || (echo "Unit testing of the source code failed." && exit 1)
 
     # Applet gets remade if we do this before 'make install'
     # NOTE: call helper script for signing jar

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -42,6 +42,7 @@ popd
 pushd $SOURCE_DIR/ndt
     export CPPFLAGS="-I$BUILD_DIR/build/include -I$BUILD_DIR/build/include/web100"
     export LDFLAGS="-L$BUILD_DIR/build/lib"
+    export LD_LIBRARY_PATH="$BUILD_DIR/build/lib"
     ./bootstrap
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
     # Run unit tests on source before making and installing


### PR DESCRIPTION
Apparently `make install` puts some files in various places that the tests in `make check` expect to find. Reversing these two should have the requisite files in place for `make check` to complete.  Also, `make check` tests fail if they cannot located the shared library libweb100.so.0, so we set LD_LIBRARY_PATH so it can find it.