### PR TITLE
Adds NDT_HOSTNAME environment variable

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -43,6 +43,7 @@ pushd $SOURCE_DIR/ndt
     export CPPFLAGS="-I$BUILD_DIR/build/include -I$BUILD_DIR/build/include/web100"
     export LDFLAGS="-L$BUILD_DIR/build/lib"
     export LD_LIBRARY_PATH="$BUILD_DIR/build/lib"
+    export NDT_HOSTNAME="localhost"
     ./bootstrap
     ./configure --enable-fakewww --prefix=$BUILD_DIR/build
     # Run unit tests on source before making and installing


### PR DESCRIPTION
Among other tests, `make check` launches web100srv so that full Node.js WebSocket tests can be run against it.  This PR adds a new environment variable, NDT_HOSTNAME, which lets the test know which server to connect to for running the tests... in this case the local machine.