### PR TITLE
Remove the svn-module dependency for I2util

### DIFF
--- a/svn-submodules
+++ b/svn-submodules
@@ -1,1 +1,0 @@
-217 http://anonsvn.internet2.edu/svn/I2util/trunk/ I2util


### PR DESCRIPTION
This is part of the cleanup of I2util handling that is breaking builds on the new docker based builder.  Without these changes, it works only on older NDT versions.