### PR TITLE
Removes Subversion checkout of I2util, and moves it to a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ndt"]
 	path = ndt 
 	url = https://github.com/m-lab/ndt
+[submodule "I2util"]
+	path = I2util
+	url = https://github.com/m-lab/I2util-archive

--- a/svn-submodules
+++ b/svn-submodules
@@ -1,1 +1,0 @@
-217 http://anonsvn.internet2.edu/svn/I2util/trunk/ I2util


### PR DESCRIPTION
anonsvn.internet2.edu isn't working, and this is where we have always fetched the I2util source when building NDT.  I went searching for information on where it had gone, and lo and behold, I found that @gfr10598 had already discovered this and had copied the specific revision we use into an M-Lab repository. 

This PR just changes our build environment to use our own git repository (as a submodule of this repo) for I2util (since it is unlikely to change, for our purposes) instead of I2's SVN repository.