### PR TITLE
Forces install of Node.js module 'ws' to v1.1.4

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -52,7 +52,7 @@ pushd $SOURCE_DIR/ndt
 
     # The Node.js WebSocket tests in "make check" require these modules
     pushd $SOURCE_DIR/ndt/src/node_tests
-        npm install ws minimist
+        npm install ws@1.1.4 minimist
     popd
     make check || (echo "Unit testing of the source code failed." && exit 1)
 


### PR DESCRIPTION
In trying to build a new NDT package, I was getting an error from Node.js during the unit tests:

```
Running test test_node_meta_test. 
/home/mlab_builder/builder/iupui_ndt/ndt/src/node_tests/node_modules/ws/index.js:9
const WebSocket = require('./lib/WebSocket');
^^^^^
SyntaxError: Use of const in strict mode.
```

From a  [closed issue I found on the 'wscat' Github repository](https://github.com/websockets/wscat/issues/37), I'm inferring that the 'ws' module >=2.0 requires Node.js >=4.0, yet all we have installed is 0.10.x.

Rather than trying to get a newer version of Node.js into our old build environment, this PR simply causes 'ws' v1.1.4 to be installed (the last release of 1.x, as far as I can tell).