### PR TITLE
Disable rDNS in NDT using LD_PRELOAD

### DIFF
--- a/getnameinfo.c
+++ b/getnameinfo.c
@@ -1,0 +1,27 @@
+// A simple LD_PRELOAD wrapper around getnameinfo that unconditionally sets
+// NI_NUMERICHOST and NI_NUMERICSERV flags.
+
+#include <netdb.h>
+#define __USE_GNU
+#include <dlfcn.h>
+
+// NOTE: on CentOS 6, the flags parameter is declared as unsigned.
+#ifdef __i386__
+int getnameinfo(
+    const struct sockaddr *sa,
+    socklen_t salen, char *host,
+    socklen_t hostlen, char *serv,
+    socklen_t servlen, unsigned int flags) {
+#else
+int getnameinfo(
+    const struct sockaddr *sa,
+    socklen_t salen, char *host,
+    socklen_t hostlen, char *serv,
+    socklen_t servlen, int flags) {
+#endif
+  if (res_init () < 0) {
+      return -1;
+  }
+  int (*f)() = dlsym (RTLD_NEXT, "getnameinfo");
+  return f(sa, salen, host, hostlen, serv, servlen, flags|NI_NUMERICHOST|NI_NUMERICSERV);
+}

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -70,6 +70,12 @@ pushd $SOURCE_DIR/ndt
     done
 popd
 
+# NOTE: Build the getnameinfo LD_PRELOAD library.
+pushd $SOURCE_DIR/
+    gcc -shared -ldl -fPIC getnameinfo.c -o $BUILD_DIR/build/lib/getnameinfo.so
+popd
+
+
 cp -r $SOURCE_DIR/init             $BUILD_DIR/
 cp    $SOURCE_DIR/tcpbw100.html    $BUILD_DIR/
 cp    $SOURCE_DIR/flashpolicy.xml  $BUILD_DIR/

--- a/init/start.sh
+++ b/init/start.sh
@@ -38,7 +38,10 @@ if ! pgrep -f ndtd &> /dev/null ; then
     [ -f $logpath/web100srv.log.1 ] && mv $logpath/web100srv.log.1 $logpath/web100srv.log.2
     [ -f $logpath/web100srv.log   ] && mv $logpath/web100srv.log $logpath/web100srv.log.1
     # ndtd must run as root
-    nohup $path/ndtd $WEB100SRV_OPTIONS 2>&1 | $SLICEHOME/init/logger.py /var/log/web100srv.debug &
+    # Load the getnameinfo library to disable all rDNS requests.
+    LD_PRELOAD=$SLICEHOME/build/lib/getnameinfo.so \
+        nohup $path/ndtd $WEB100SRV_OPTIONS 2>&1 \
+            | $SLICEHOME/init/logger.py /var/log/web100srv.debug &
     touch /var/lock/subsys/ndtd
 fi
 


### PR DESCRIPTION
This change adds a new shared library that unconditionally sets the `NI_NUMERICHOST` and `NI_NUMERICSERV` flags on calls to `getnameinfo`.

This change includes changes to the ndt-support `start.sh` script to enable this behavior in the NDT server using `LD_PRELOAD`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/42)
<!-- Reviewable:end -->
