### PR TITLE
Add inotify_exporter to the ndt-support package

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -75,6 +75,19 @@ pushd $SOURCE_DIR/
     gcc -shared -ldl -fPIC getnameinfo.c -o $BUILD_DIR/build/lib/getnameinfo.so
 popd
 
+pushd $SOURCE_DIR/
+    export GOPATH=$PWD/go
+    mkdir -p $GOPATH
+    # Get source and all dependencies, and do not build.
+    go get -d github.com/m-lab/inotify-exporter/cmd/inotify_exporter
+    cd $GOPATH/go/src/github.com/m-lab/inotify-exporter
+    # Checkout a specific production tag.
+    git checkout -q tags/production/0.1
+    # Build that version.
+    go install github.com/m-lab/inotify-exporter/cmd/inotify_exporter
+    cp go/src/inotify_exporter $BUILD_DIR/build/bin/
+popd
+
 
 cp -r $SOURCE_DIR/init             $BUILD_DIR/
 cp    $SOURCE_DIR/tcpbw100.html    $BUILD_DIR/

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -80,12 +80,13 @@ pushd $SOURCE_DIR/
     mkdir -p $GOPATH
     # Get source and all dependencies, and do not build.
     go get -d github.com/m-lab/inotify-exporter/cmd/inotify_exporter
-    cd $GOPATH/go/src/github.com/m-lab/inotify-exporter
-    # Checkout a specific production tag.
-    git checkout -q tags/production/0.1
+    pushd go/src/github.com/m-lab/inotify-exporter
+      # Checkout a specific production tag.
+      git checkout -q tags/production/0.1
+    popd
     # Build that version.
     go install github.com/m-lab/inotify-exporter/cmd/inotify_exporter
-    cp go/src/inotify_exporter $BUILD_DIR/build/bin/
+    cp go/bin/inotify_exporter $BUILD_DIR/build/bin/
 popd
 
 

--- a/init/start.sh
+++ b/init/start.sh
@@ -61,6 +61,7 @@ if ! pgrep -f flashpolicyd.py &> /dev/null ; then
 fi
 
 if ! pgrep -f inotify_exporter &> /dev/null ; then
+    echo "Starting inotify_exporter:"
     nohup $SLICEHOME/build/bin/inotify_exporter --path /var/spool/iupui_ndt &> /dev/null &
     touch /var/lock/subsys/inotify_exporter
 fi

--- a/init/start.sh
+++ b/init/start.sh
@@ -42,13 +42,17 @@ if ! pgrep -f ndtd &> /dev/null ; then
     LD_PRELOAD=$SLICEHOME/build/lib/getnameinfo.so \
         nohup $path/ndtd $WEB100SRV_OPTIONS 2>&1 \
             | $SLICEHOME/init/logger.py /var/log/web100srv.debug &
-    touch /var/lock/subsys/ndtd
+    pgrep -f ndtd > /var/lock/subsys/ndtd
+else
+    echo "Already running: ndtd"
 fi
 
 if ! pgrep -f fakewww &> /dev/null ; then
     echo "Starting fakewww:"
     nohup $path/fakewww $FAKEWWW_OPTIONS > /dev/null 2>&1 &
-    touch /var/lock/subsys/fakewww
+    pgrep -f fakewww > /var/lock/subsys/fakewww
+else
+    echo "Already running: fakewww"
 fi
 
 if ! pgrep -f flashpolicyd.py &> /dev/null ; then
@@ -57,11 +61,15 @@ if ! pgrep -f flashpolicyd.py &> /dev/null ; then
     [ -f $flashpolicyd_log.1 ] && mv $flashpolicyd_log.1 $flashpolicyd_log.2
     [ -f $flashpolicyd_log   ] && mv $flashpolicyd_log $flashpolicyd_log.1
     nohup $SLICEHOME/flashpolicyd.py > /dev/null 2> $flashpolicyd_log &
-    touch /var/lock/subsys/flashpolicyd.py
+    pgrep -f flashpolicyd.py > /var/lock/subsys/flashpolicyd.py
+else
+    echo "Already running: flashpolicyd.py"
 fi
 
 if ! pgrep -f inotify_exporter &> /dev/null ; then
     echo "Starting inotify_exporter:"
     nohup $SLICEHOME/build/bin/inotify_exporter --path /var/spool/iupui_ndt &> /dev/null &
-    touch /var/lock/subsys/inotify_exporter
+    pgrep -f inotify_exporter > /var/lock/subsys/inotify_exporter
+else
+    echo "Already running: inotify_exporter"
 fi

--- a/init/start.sh
+++ b/init/start.sh
@@ -59,3 +59,8 @@ if ! pgrep -f flashpolicyd.py &> /dev/null ; then
     nohup $SLICEHOME/flashpolicyd.py > /dev/null 2> $flashpolicyd_log &
     touch /var/lock/subsys/flashpolicyd.py
 fi
+
+if ! pgrep -f inotify_exporter &> /dev/null ; then
+    nohup $SLICEHOME/build/bin/inotify_exporter --path /var/spool/iupui_ndt &> /dev/null &
+    touch /var/lock/subsys/inotify_exporter
+fi

--- a/init/stop.sh
+++ b/init/stop.sh
@@ -3,27 +3,27 @@
 sudo -s <<\EOF
 source /etc/mlab/slice-functions
 
-if pgrep -f ndtd &> /dev/null ; then
+if test -f /var/lock/subsys/ndtd ; then
     echo "Stopping ndtd:"
-    pkill -KILL -f ndtd
+    kill -KILL `cat /var/lock/subsys/ndtd`
     rm -f /var/lock/subsys/ndtd
 fi
 
-if pgrep -f fakewww &> /dev/null ; then
+if test -f /var/lock/subsys/fakewww ; then
     echo "Stopping fakewww:"
-    pkill -TERM -f fakewww
+    kill -TERM `cat /var/lock/subsys/fakewww`
     rm -f /var/lock/subsys/fakewww
 fi
 
-if pgrep -f flashpolicyd.py &> /dev/null ; then
+if test -f /var/lock/subsys/flashpolicyd.py ; then
     echo "Stopping flashpolicyd.py:"
-    pkill -TERM -f flashpolicyd.py
+    kill -TERM `cat /var/lock/subsys/flashpolicyd.py`
     rm -f /var/lock/subsys/flashpolicyd.py
 fi
 
-if pgrep -f inotify_exporter &> /dev/null ; then
+if test -f /var/lock/subsys/inotify_exporter ; then
     echo "Stopping inotify_exporter:"
-    pkill -TERM -f inotify_exporter
+    kill -TERM `cat /var/lock/subsys/inotify_exporter`
     rm -f /var/lock/subsys/inotify_exporter
 fi
 EOF

--- a/init/stop.sh
+++ b/init/stop.sh
@@ -20,4 +20,10 @@ if pgrep -f flashpolicyd.py &> /dev/null ; then
     pkill -TERM -f flashpolicyd.py
     rm -f /var/lock/subsys/flashpolicyd.py
 fi
+
+if pgrep -f inotify_exporter &> /dev/null ; then
+    echo "Stopping inotify_exporter:"
+    pkill -TERM -f inotify_exporter
+    rm -f /var/lock/subsys/inotify_exporter
+fi
 EOF


### PR DESCRIPTION
This change adds the inotify_exporter to the NDT support package.

With this change, the inotify_exporter is built and included in the NDT RPM. When NDT starts or stops, the inotify exporter is also started or stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/44)
<!-- Reviewable:end -->
