### PR TITLE
Add a staging deploy target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,15 @@ deploy:
      condition: $TRAVIS_BRANCH == sandbox-* && $TRAVIS_EVENT_TYPE == push
    skip_cleanup: true
 
+ # STAGING - reviewed, untagged, deploy to gs://legacy-rpms-mlab-staging
+ - provider: script
+   script: $TRAVIS_BUILD_DIR/deploy_rpm.sh
+       "$SERVICE_ACCOUNT_mlab_staging"
+       $TRAVIS_BUILD_DIR/build/slicebase-i386/i686/iupui_ndt-*.rpm
+       gs://legacy-rpms-mlab-staging/slicebase-i386/i686/
+   on:
+     repo: m-lab/ndt-support
+     all_branches: true
+     condition: $TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push
+   skip_cleanup: true
+


### PR DESCRIPTION
This change adds a travis deploy target for the `gs://legacy-rpms-mlab-staging` bucket.

This will automatically build a new NDT RPM and deploy it to the staging bucket after merges to the master branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/45)
<!-- Reviewable:end -->
