### PR TITLE
Modifies stop.sh to kill all ndtd processes in the PGID

### DIFF
--- a/init/stop.sh
+++ b/init/stop.sh
@@ -5,6 +5,10 @@ source /etc/mlab/slice-functions
 
 if test -f /var/lock/subsys/ndtd ; then
     echo "Stopping ndtd:"
+    # Note the minus sign (`-`) before the `cat` command substitution below.
+    # This is a special syntax for `kill`, telling it to not just kill the PID,
+    # but to kill every process in the PID's process group. This will
+    # effectively kill the parent ndtd process, along with any children.
     kill -KILL -$(cat /var/lock/subsys/ndtd)
     rm -f /var/lock/subsys/ndtd
 fi

--- a/init/stop.sh
+++ b/init/stop.sh
@@ -5,25 +5,25 @@ source /etc/mlab/slice-functions
 
 if test -f /var/lock/subsys/ndtd ; then
     echo "Stopping ndtd:"
-    kill -KILL `cat /var/lock/subsys/ndtd`
+    kill -KILL -$(cat /var/lock/subsys/ndtd)
     rm -f /var/lock/subsys/ndtd
 fi
 
 if test -f /var/lock/subsys/fakewww ; then
     echo "Stopping fakewww:"
-    kill -TERM `cat /var/lock/subsys/fakewww`
+    kill -TERM $(cat /var/lock/subsys/fakewww)
     rm -f /var/lock/subsys/fakewww
 fi
 
 if test -f /var/lock/subsys/flashpolicyd.py ; then
     echo "Stopping flashpolicyd.py:"
-    kill -TERM `cat /var/lock/subsys/flashpolicyd.py`
+    kill -TERM $(cat /var/lock/subsys/flashpolicyd.py)
     rm -f /var/lock/subsys/flashpolicyd.py
 fi
 
 if test -f /var/lock/subsys/inotify_exporter ; then
     echo "Stopping inotify_exporter:"
-    kill -TERM `cat /var/lock/subsys/inotify_exporter`
+    kill -TERM $(cat /var/lock/subsys/inotify_exporter)
     rm -f /var/lock/subsys/inotify_exporter
 fi
 EOF


### PR DESCRIPTION
While using the ndt-ssl Ansible playbook to deploy SSL cert and key to NDT slivers, I noticed that for some reason ndtd was no longer running in the sliver after the playbook finished. The playbook runs `service slicectrl restart`, which itself just runs _stop.sh_ and _start.sh_. What I discovered was that _stop.sh_ kill the parent ndtd process (by PID), but that any children were left running. What would then happen is that _start.sh_ would run, would see that there were processes named `ndtd` and would not start ndtd, thinking it was already running. Then, within 10 or 20 seconds the child ndtd processes would themselves exit, and no ndtd would be running at all.

This PR add a "negative" PID flag to the parent ndtd PID, which instructs `kill` to kill all the processes in the parent's PGID, which effectively kills the parent, along with any children.

This PR also updates the command substitution syntax from the older backtick notation to the newer `$()` notation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/48)
<!-- Reviewable:end -->
