### PR TITLE
Removes Travis caching for /home/nkinkade/google-cloud-sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ services:
 
 cache:
   pip: true
-  directories:
-    - $HOME/google-cloud-sdk/
 
 script:
   - pip install google-compute-engine


### PR DESCRIPTION
Travis discourages caching '[Large files that are quick to install but slow to download](https://docs.travis-ci.com/user/caching/#Things-not-to-cache)'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/49)
<!-- Reviewable:end -->
