### PR TITLE
Makes NDT Travis builds a lot less verbose, which may also get around a Travis bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ cache:
 script:
   - pip install google-compute-engine
   - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
-  - $TRAVIS_BUILD_DIR/build_rpm.sh "DISABLE_APPLET_SIGNING=1 ./package/slicebuild.sh iupui_ndt"
+  - $TRAVIS_BUILD_DIR/build_rpm.sh "DISABLE_APPLET_SIGNING=1
+    ./package/slicebuild.sh iupui_ndt > build.log || cat build.log"
 
 deploy:
  # Sandbox - unreviewed, untagged, deploy to gs://legacy-rpms-mlab-sandbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - pip install google-compute-engine
   - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
   - $TRAVIS_BUILD_DIR/build_rpm.sh "DISABLE_APPLET_SIGNING=1
-    ./package/slicebuild.sh iupui_ndt > build.log || cat build.log"
+    ./package/slicebuild.sh iupui_ndt &> build.log || cat build.log"
 
 deploy:
  # Sandbox - unreviewed, untagged, deploy to gs://legacy-rpms-mlab-sandbox

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -17,5 +17,5 @@ set -e
 USAGE="$0 'command to run in builder'"
 _=${1:?Please provide a command to run: $USAGE}
 docker pull measurementlab/builder:production-1.0
-docker run -it -v `pwd`:/root/building \
+docker run -v `pwd`:/root/building \
     measurementlab/builder:production-1.0 bash -c "cd /root/building; $@"

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -18,5 +18,4 @@ USAGE="$0 'command to run in builder'"
 _=${1:?Please provide a command to run: $USAGE}
 docker pull measurementlab/builder:production-1.0
 docker run -it -v `pwd`:/root/building \
-    measurementlab/builder:production-1.0 bash -c "cd /root/building; $@" > \
-    /dev/null
+    measurementlab/builder:production-1.0 bash -c "cd /root/building; $@"

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -18,4 +18,5 @@ USAGE="$0 'command to run in builder'"
 _=${1:?Please provide a command to run: $USAGE}
 docker pull measurementlab/builder:production-1.0
 docker run -it -v `pwd`:/root/building \
-    measurementlab/builder:production-1.0 bash -c "cd /root/building; $@"
+    measurementlab/builder:production-1.0 bash -c "cd /root/building; $@" > \
+    /dev/null


### PR DESCRIPTION
This branch contains two commits, one to update the travis submodule, which contains a change to make installing google-cloud-sdk a lot less verbose, and another to this repository which sends all NDT RPM build messages to /dev/null. Both of these changes make reading the Travis logs a lot easier, and it also actually causes the build to succeed. It would appear there is some [limitation (bug?) in the latest Travis Ubuntu Trusty images where builds may fail when scripts output too much data to stdout](https://github.com/travis-ci/travis-ci/issues/4704).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/50)
<!-- Reviewable:end -->
