### PR TITLE
Fixes the verbosity of NDT RPM build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - pip install google-compute-engine
   - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
   - $TRAVIS_BUILD_DIR/build_rpm.sh "DISABLE_APPLET_SIGNING=1
-    ./package/slicebuild.sh iupui_ndt &> build.log || cat build.log"
+    ./package/slicebuild.sh iupui_ndt" &> build.log || cat build.log
 
 deploy:
  # Sandbox - unreviewed, untagged, deploy to gs://legacy-rpms-mlab-sandbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - pip install google-compute-engine
   - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
   - $TRAVIS_BUILD_DIR/build_rpm.sh "DISABLE_APPLET_SIGNING=1
-    ./package/slicebuild.sh iupui_ndt" &> build.log || cat build.log
+    ./package/slicebuild.sh iupui_ndt" &> build.log || (cat build.log && false)
 
 deploy:
  # Sandbox - unreviewed, untagged, deploy to gs://legacy-rpms-mlab-sandbox

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -17,5 +17,5 @@ set -e
 USAGE="$0 'command to run in builder'"
 _=${1:?Please provide a command to run: $USAGE}
 docker pull measurementlab/builder:production-1.0
-docker run -v `pwd`:/root/building \
+docker run -t -v `pwd`:/root/building \
     measurementlab/builder:production-1.0 bash -c "cd /root/building; $@"


### PR DESCRIPTION
Logs to a file, and only prints contents of file if build_rpm.sh exits with a non-zero status. I've tested this on my local machine and it *seems* to work as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/51)
<!-- Reviewable:end -->
