### PR TITLE
Update web100_userland archive link to vendor directory URL

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -52,6 +52,9 @@ pushd $SOURCE_DIR/ndt
 
     # The Node.js WebSocket tests in "make check" require these modules
     pushd $SOURCE_DIR/ndt/src/node_tests
+        # Note: npm has a known issue with validating SSL certs. This disables
+        # strict ssl checks when installing the following package.
+        npm config set strict-ssl false
         npm install ws@1.1.4 minimist
     popd
     make check || (echo "Unit testing of the source code failed." && exit 1)

--- a/tar-archives
+++ b/tar-archives
@@ -1,1 +1,1 @@
-web100_userland-1.8.tar.gz http://www.web100.org/download/userland/version1.8/web100_userland-1.8.tar.gz
+web100_userland-1.8.tar.gz https://storage.googleapis.com/vendor-mlab-oti/ndt-support/web100_userland-1.8.tar.gz


### PR DESCRIPTION
The web100.org web site is either offline or no longer maintained. In order to continue supporting new builds of the legacy NDT web100 server, we will maintain a vendor copy of the userland library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-support/53)
<!-- Reviewable:end -->
